### PR TITLE
Changed default search setting for H and dLR

### DIFF
--- a/html/search.template.html
+++ b/html/search.template.html
@@ -78,7 +78,7 @@
 <TR>
     <TD colspan=2>Search Width:<br>(models to keep at each level)</TD>
     <TD><INPUT type="text" size="4" name="searchwidth" value="3"></TD>
-</TR>	
+</TR>
 <TR>
     <TD colspan=2>Search Levels:</TD>
     <TD><INPUT type="text" size="4" name="searchlevels" value="7">&nbsp;&nbsp;(leave blank to use settings from data file)</TD>
@@ -112,8 +112,8 @@
 
 <TR>
     <TD colspan=2>Include in Report:</TD>
-    <TD><INPUT type="checkbox" name="show_h" value="yes" checked>H&nbsp;
-        <INPUT type="checkbox" name="show_dlr" value="yes" checked>dLR&nbsp;
+    <TD><INPUT type="checkbox" name="show_h" value="yes">H&nbsp;
+        <INPUT type="checkbox" name="show_dlr" value="yes">dLR&nbsp;
         <INPUT type="checkbox" name="show_pct_dh" value="yes" checked>% dH(DV)&nbsp;
         <INPUT type="checkbox" name="show_aic" value="yes" checked>dAIC&nbsp;
         <INPUT type="checkbox" name="show_bic" value="yes" checked>dBIC</TD>


### PR DESCRIPTION
 Under 'include in report', H and dLR should be unchecked by default per Marty ("users who do not know RA theory will not be able to use these measures, and thus do not need to see them")