### PR TITLE
OCCAM Installation Script and Simplified Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 occ
 install
+mostRecentRun.txt

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,187 +2,48 @@
 
 ## Overview
 
-The current version of OCCAM runs on a linux webserver. The installation procedure is fairly well defined for linux, so you should be able to get OCCAM up and running on your linux system. This will probably require the use of virtual environment (described below) or some other method to control the python environment. For most users, the recommended installation method at this time is to use VirtualBox, which will let you create a fully containerized linux machine inside your existing OS. This will isolate OCCAM inside the VirtualBox and not require configuration changes to your larger system. The procedure is as follows:
+The current version of OCCAM runs as a linux webserver. The installation procedure is fairly well defined for linux, so you should be able to get OCCAM up and running on most linux systems, but this procedure will describe the process using Ubuntu on VirtualBox.
 
-1. Install a virtual machine or virtual environment, and install Ubuntu or some other Linux server on your (virtual) machine, and install dependencies
-2. Install OCCAM using git
-3. Install apache and configure it for CGI-bin
-4. Set file ownership and permissions to allow apache to access the files
-
-So let's begin:
+1. Install a virtual machine or virtual environment
+2. Install Ubuntu 18.04
+3. Install OCCAM using the install script
 
 ### Install VirtualBox
 
-To create an instance of OCCAM without a dedicated Linux machine you can [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads).  Select New and make sure it is of the Linux type with enough memory and storage space to run the chosen OS.
+[Download VirtualBox](https://www.virtualbox.org/wiki/Downloads), install and run it.
 
-You'll want to make sure your box is "Attached to" a Bridged Adapter in Network settings for Adapter 1, but the rest of the settings based mostly on the preference of the user and limitations of the host machine.
+Select New and choose Type: Linux and Version: Ubuntu (64-bit).
 
-You can then create a Linux server box by installing from an ISO, like these [Ubuntu ISOs](http://releases.ubuntu.com/16.04/).
+You can use the default hardware settings, but adding more RAM and Hardware storage will help analyze larger datasets.
 
-### Install Ubuntu Server 16.04
+After the box is created, go into the Settings for the Box and set "Attached to" as Bridged Adapter in Network for Adapter 1.
 
-Choose the Ubuntu Server for either 32-bit or 64-bit (depending on the host OS) from [ISOs](http://releases.ubuntu.com/16.04/).
+Next you'll need to set the Virtual Optical Storage to the Ubuntu 18.04 ISO you'll download next.
 
-Use at least 2GB of memory and 5GB of storage.
+### Install Ubuntu Server 18.04
 
-**OR**
+Choose the Ubuntu Server for 64-bit from [ISOs](http://releases.ubuntu.com/18.04/).  Install this ISO into the Virtual Optical Disk in the Storate Settings for your Box.
 
-Install Ubuntu Server 16.04 on your own hardware or other virtual machine.
+Start the Box and then follow the prompts for installing Ubuntu Server.  You should be able to use all the default settings, but you may want to check the box to install OpenSSH Server so that you can connect using SSH to continue the rest of the install.
 
-**OR**
-
-Skip this step and attempt to install this on an existing Ubuntu install.
-
-During the installation you should get some options to install additional packages, you will want to install 'LAMP server'.
-
-I also installed PostgresSQL database for possible development with that, and also OpenSSH Server so that I could SSH into the server and SCP files between any of my computers, but these are not required to get OCCAM running.
-
-## Install Dependencies
-
-If you didn't do it during installation you'll need to install Apache2 and Python2.
-
-Check to see if you have them installed and see which versions:
-
-```
-$ apache2 -v
-$ python -V
-```
-**Note**: Must be Python 2.7.x
-
-Once you verify that Apache and Python are installed, you'l need to install a number of other depencies for OCCAM:
-
-```
-$ sudo apt-get update
-$ sudo apt-get install gcc build-essential libgmp3-dev python-dev libxml2 libxml2-dev zlib1g-dev python-pip
-$ pip install python-igraph
-```
-
-### Virtual Environments
-
-Some users might wish to install OCCAM directly on a linux hardware machine, bypassing machine virtualization. Doing so will probably require virtual environments or some other method to let you control your python environment for OCCAM (particularly if you are installing on a machine which contains an existing python configuration and applications which depend on it. Here is how to do that. First, install virtualenv:
-
-```
-$ sudo apt-get install virtualenv
-
-$ virtualenv -p /usr/bin/python2.7 occam/
-```
-(or replace 'occam' with your desired directory name). We need to use -p instead of just running 'virtualenv occam/', which would set up the environment, but not with python2.7, which is what we need.
-
-Now activate the environment:
-```
-$ source occam/bin/activate
-```
-
-When the environment is active, its name will appear in front of your command prompt, like:
-
-```
-(occam) user@host $
-```
- 
-Once the environment is activated, anything that you do that makes environment changes (like install packages) will now change your virtual environment configuration, and not your global configuration. With an active virtual environment, using pip to install, uninstall, or upgrade packages (or do anything else that makes changes to your python environment) will now make those package changes to the virtual environment and not your global environment, so you could have one version of a package for the occam environment and another for your global configuration, and yet another in a different virtual environment for a different application. This will avoid version conflicts and allow your existing python applications to run as they currently do, and to run OCCAM with the interpreter and package version that it needs.
-
-Now that you have done the setup of your virtual machine or environment, you can actually install OCCAM.
+When prompted to set the name, server name, and username, it's recommended here to use `occam` for them all.  Password is left to your discretion.  Reboot when the installation is complete.
 
 ### Install OCCAM
 
-Now that you have a machine with the right dependencies set up, you can install and setup OCCAM.  First you need to get the OCCAM repository onto your machine.  You can do this by downloading the ZIP unzipping the folder wherever you like, or by using git.
+Once the server reboots you can log in as `occam`.  Then run the following commands:
 
 ```
-$ sudo apt install git
 $ git clone https://github.com/occam-ra/occam.git
 $ cd occam
-$ make install
-```
-**Note**: Make sure you have read and write permissions for the directory where you wish to install OCCAM before cloning and running make. See below under "Setting Permissions" if you need more details on permissions.
-**Note**: Contributors will likely want to clone their own forks. 
-
-OCCAM should now be installed in the `install` folder.
-
-At this point OCCAM should be all setup.  Now you need to make sure Apache is serving it correctly.
-
-### Setup Apache
-
-Apache should already be running, so you just need to point the default site to your `occam/install/web` directory, setup the VirtualDirectory and make sure that CGI is enabled.
-
-```
-$ sudo a2enmod cgi
-$ sudo vi /etc/apache2/sites-enabled/000-default.conf
+$ ./install_occam.sh
 ```
 
-You'll want to add or change the following lines in that configuration file:
+OCCAM everything is finished installing you should now have OCCAM installed in the `install` folder.
+
+Get the IP address by running the following command:
 
 ```
-	#DocumentRoot /path/to/occam/install/web
-	# e.g.
-	DocumentRoot /home/occam/occam/install/web
-
-	# Add this toward the bottom
-	#<Directory /path/to/occam/install/web>
-	# e.g.
-	<Directory /home/occam/occam/install/web>
-		Options +ExecCGI
-		AddHandler cgi-script .cgi .pl
-		options Indexes FollowSymLinks
-		AllowOverride All
-		Require all granted
-	</Directory>
+$ ifconfig | grep "inet" | head -n 1
 ```
 
-Finally, there are some permission issues that happen sometimes, so my solution was to edit the `/etc/apache2/envars` file to make Apache run as my default unix user (occam):
-
-```
-$ sudo vi /etc/apache2/envvars
-```
-
-Edit to use your default unix user/group in place of `occam`.
-
-```
-# CHANGE
-# export APACHE_RUN_USER=www-data
-# export APACHE_RUN_GROUP=www-data
-# TO
-export APACHE_RUN_USER=occam
-export APACHE_RUN_GROUP=occam
-```
-
-### Setting Permissions
-
-Another approach to this is to set owernship and permissions so that apache will have access without having to change the apache user (which, again, might cause problems on systems with existing applications that depend on the current apache configuration). 
-
-From your OCCAM install directory (the install/ directory created when you ran make), do:
-
-```
-$ chown -R snoopy web/
-
-$ chgrp -R www-data web/
-
-$ chmod -R 750 web/
-
-$ chmod g+s web/
-
-$ chmod g+w web/data/
-```
-This will recursively set ownership of the occam web directory to the user you desire on your system; change group ownership to the www-data group; change file permissions to [0750 = User: rwx  Group: r-x  World: --- (i.e. World: no access)]; set new files created in this directory to have their group set to the directory's group; and add group write privileges for the data/ subdirectory. It avoids the insecure 'chmod 777' and uses group permissions so you don't have to change your apache user.
-
-The last step is very important, because OCCAM creates temporary versions of the data files, so the www-data group needs write permissions for that directory. If you don't do this last step, OCCAM will run part of the way - the front form will come up, and you can choose a data file and set search options, but when you run the search you will get a permissions error because the data file cannot be created on the server.
-
-#### Remapping the URL with aliasing
-
-You might want to use aliasing to remap your URL and filesystem location. By default your OCCAM URL will be something like http://localhost/occam/install/web which you might want to clean up to localhost/occam. You might also have other reasons for this depending on your webserver configuration.
-
-Add this directive to your apache config file for this site:
-
-```
-Alias "/occam" "/var/www/html/occam/install/web"
-```
-replacing '/occam' with your desired URL directory, and the '/var/www...' part with the filesystem location where you installed occam. 
-
-Now, you should be able to restart apache and take your IP address...
-
-```
-$ sudo service apache2 restart
-$ ifconfig | grep "inet addr" | head -n 1
-		inet addr:10.0.0.165  Bcast:10.0.0.255  Mask:255.255.255.0
-```
-
-Now you can open a browser window (probably to http://localhost/occam/install/web, or possibly to http://localhost/occam if you remapped the URL directory) to first IP address and view your fully operational OCCAM session!
+Now you should be able to browse to that IP address in your web browser of choice and see a running OCCAM installation.

--- a/install_occam.sh
+++ b/install_occam.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Update apt
+sudo apt update
+sudo apt upgrade
+
+# Install dependencies
+sudo apt install -y apache2
+sudo apt install -y python2.7 python-pip
+sudo apt install -y gcc build-essential libgmp3-dev python-dev libxml2 libxml2-dev zlib1g-dev
+
+# Make OCCAM
+make install
+
+# Setup Apache
+sudo a2enmod cgi
+echo <<EOT >> /etc/apache2/sites-enabled/000-default.conf
+<VirtualHost *:80>
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	#ServerName www.example.com
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /home/occam/occam/install/web
+
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+	<Directory /home/occam/occam/install/web>
+		Options +ExecCGI
+		AddHandler cgi-script .cgi .pl
+		options Indexes FollowSymLinks
+		AllowOverride All
+		Require all granted
+	</Directory>
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet
+EOT
+
+# TODO Change /etc/apache2/envvars
+
+# Set Permissions
+chown -R www-data install/web/
+chgrp -R www-data install/web/
+chmod -R 750 install/web/
+chmod g+s install/web/
+chmod g+w install/web/data/
+
+# 

--- a/install_occam.sh
+++ b/install_occam.sh
@@ -8,13 +8,15 @@ sudo apt upgrade
 sudo apt install -y apache2
 sudo apt install -y python2.7 python-pip
 sudo apt install -y gcc build-essential libgmp3-dev python-dev libxml2 libxml2-dev zlib1g-dev
+pip install python-igraph
 
 # Make OCCAM
 make install
 
 # Setup Apache
 sudo a2enmod cgi
-echo <<EOT >> /etc/apache2/sites-enabled/000-default.conf
+#cat <<EOT >> /etc/apache2/sites-enabled/000-default.conf
+sudo tee -a /etc/apache2/sites-enabled/000-default.conf > /dev/null <<EOT
 <VirtualHost *:80>
 	# The ServerName directive sets the request scheme, hostname and port that
 	# the server uses to identify itself. This is used when creating
@@ -56,12 +58,62 @@ echo <<EOT >> /etc/apache2/sites-enabled/000-default.conf
 EOT
 
 # TODO Change /etc/apache2/envvars
+#cat <<EOT >> /etc/apache2/envvars
+sudo tee -a /etc/apache2/envvars > /dev/null <<EOT
+# envvars - default environment variables for apache2ctl
+
+# this won't be correct after changing uid
+unset HOME
+
+# for supporting multiple apache2 instances
+if [ "${APACHE_CONFDIR##/etc/apache2-}" != "${APACHE_CONFDIR}" ] ; then
+	SUFFIX="-${APACHE_CONFDIR##/etc/apache2-}"
+else
+	SUFFIX=
+fi
+
+# Since there is no sane way to get the parsed apache2 config in scripts, some
+# settings are defined via environment variables and then used in apache2ctl,
+# /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
+export APACHE_RUN_USER=occam
+export APACHE_RUN_GROUP=occam
+# temporary state file location. This might be changed to /run in Wheezy+1
+export APACHE_PID_FILE=/var/run/apache2$SUFFIX/apache2.pid
+export APACHE_RUN_DIR=/var/run/apache2$SUFFIX
+export APACHE_LOCK_DIR=/var/lock/apache2$SUFFIX
+# Only /var/log/apache2 is handled by /etc/logrotate.d/apache2.
+export APACHE_LOG_DIR=/var/log/apache2$SUFFIX
+
+## The locale used by some modules like mod_dav
+export LANG=C
+## Uncomment the following line to use the system default locale instead:
+#. /etc/default/locale
+
+export LANG
+
+## The command to get the status for 'apache2ctl status'.
+## Some packages providing 'www-browser' need '--dump' instead of '-dump'.
+#export APACHE_LYNX='www-browser -dump'
+
+## If you need a higher file descriptor limit, uncomment and adjust the
+## following line (default is 8192):
+#APACHE_ULIMIT_MAX_FILES='ulimit -n 65536'
+
+## If you would like to pass arguments to the web server, add them below
+## to the APACHE_ARGUMENTS environment.
+#export APACHE_ARGUMENTS=''
+
+## Enable the debug mode for maintainer scripts.
+## This will produce a verbose output on package installations of web server modules and web application
+## installations which interact with Apache
+#export APACHE2_MAINTSCRIPT_DEBUG=1
+EOT
 
 # Set Permissions
-chown -R www-data install/web/
-chgrp -R www-data install/web/
+chown -R occam install/web/
+chgrp -R occam install/web/
 chmod -R 750 install/web/
 chmod g+s install/web/
 chmod g+w install/web/data/
 
-# 
+sudo systemctl restart apache2

--- a/install_occam.sh
+++ b/install_occam.sh
@@ -15,8 +15,7 @@ make install
 
 # Setup Apache
 sudo a2enmod cgi
-#cat <<EOT >> /etc/apache2/sites-enabled/000-default.conf
-sudo tee -a /etc/apache2/sites-enabled/000-default.conf > /dev/null <<EOT
+sudo tee /etc/apache2/sites-enabled/000-default.conf > /dev/null <<EOT
 <VirtualHost *:80>
 	# The ServerName directive sets the request scheme, hostname and port that
 	# the server uses to identify itself. This is used when creating
@@ -58,8 +57,7 @@ sudo tee -a /etc/apache2/sites-enabled/000-default.conf > /dev/null <<EOT
 EOT
 
 # TODO Change /etc/apache2/envvars
-#cat <<EOT >> /etc/apache2/envvars
-sudo tee -a /etc/apache2/envvars > /dev/null <<EOT
+sudo tee /etc/apache2/envvars > /dev/null <<EOT
 # envvars - default environment variables for apache2ctl
 
 # this won't be correct after changing uid
@@ -117,3 +115,4 @@ chmod g+s install/web/
 chmod g+w install/web/data/
 
 sudo systemctl restart apache2
+

--- a/install_occam.sh
+++ b/install_occam.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Update apt
-sudo apt update
-sudo apt upgrade
+sudo apt update -y
+sudo apt upgrade -y
 
 # Install dependencies
 sudo apt install -y apache2


### PR DESCRIPTION
Creates an `install_occam.sh` script which installs all the necessary dependencies, builds the OCCAM core library, sets permissions, and configures the apache to serve the web application on port 80.

Simplifies the `INSTALL.md` documentation to only cover installing VirtualBox with Ubuntu 18.04, cloning the OCCAM repo, and running the `install_occam.sh` script.