### PR TITLE
Initial chi squared testing and probable future replacement of "quick approximation" csa function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,12 @@ $(GTEST_LIB_DIR)/libgtest.a: $(GTEST_DIR)
 tests/test_ocReadFile: cpp/occam.so tests/test_ocReadFile.cpp $(GTEST_LIB_DIR)/libgtest.a
 	g++ -std=c++14 -isystem $(GTEST_INCLUDE_DIR) -pthread tests/test_ocReadFile.cpp -L./cpp -loccam3 $(GTEST_LIB_DIR)/libgtest.a -o tests/test_ocReadFile
 
-tests: tests/test_ocReadFile 
+tests/test_csa: cpp/occam.so tests/test_csa.cpp $(GTEST_LIB_DIR)/libgtest.a
+	g++ -std=c++14 -isystem $(GTEST_INCLUDE_DIR) -pthread tests/test_csa.cpp -L./cpp -loccam3 $(GTEST_LIB_DIR)/libgtest.a -o tests/test_csa
+
+tests: tests/test_ocReadFile tests/test_csa
 	./tests/test_ocReadFile
+	./tests/test_csa
 
 clean:
 	cd cpp && $(MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,11 @@ GTEST_DIR = tests/googletest/googletest
 GTEST_INCLUDE_DIR = $(GTEST_DIR)/include
 GTEST_LIB_DIR = $(GTEST_DIR)/lib
 
-$(GTEST_LIB_DIR)/libgtest.a:
+$(GTEST_DIR):
+	git submodule init
+	git submodule update
+
+$(GTEST_LIB_DIR)/libgtest.a: $(GTEST_DIR)
 	g++ -std=c++14 -isystem $(GTEST_INCLUDE_DIR) -I$(GTEST_DIR) -pthread -c $(GTEST_DIR)/src/gtest-all.cc && \
 	mkdir -p $(GTEST_LIB_DIR)
 	ar -rv $(GTEST_LIB_DIR)/libgtest.a gtest-all.o

--- a/cpp/Math.cpp
+++ b/cpp/Math.cpp
@@ -17,6 +17,8 @@
 #include <float.h>
 #include "Constants.h"
 
+#include <boost/math/distributions/chi_squared.hpp>
+
 double ocEntropy(Table *p) {
     double h = 0.0;
     long long count = p->getTupleCount();
@@ -614,6 +616,25 @@ double chin2(double x, double df, double theta, int *ifault) {
     }
     return 0;
 }
+
+
+double csa_boost(double x, double df) {
+    if (x == 0.0 || df == 0.0) {
+        return 1.0;
+    } else if (x < 0.0 || df < 0.0) {
+        return -1.0;
+    }
+
+    boost::math::chi_squared_distribution<double> dist(df);
+    double p = boost::math::cdf(boost::math::complement(dist, x));
+
+    if (p <= 0.0001) {
+        return 0.0;
+    }
+
+    return p;
+}
+
 
 /*
  A quick approximation to upper-tail probabilities of

--- a/include/Math.h
+++ b/include/Math.h
@@ -86,6 +86,7 @@ double ocLR(double sample, double df, double h);
 double chic (double x2, double df);
 double chin2 (double x, double df, double theta, int *ifault);
 double csa (double x, double df);
+double csa_boost (double x, double df);
 //static double ppnorm (double prob, int *ifault);
 double gammds (double y, double p, int *ifault);
 double ppchi (double p, double df, int *ifault);

--- a/podman/Dockerfile
+++ b/podman/Dockerfile
@@ -30,10 +30,15 @@ ARG GITHUB_USERNAME=""
 ARG GITHUB_EMAIL=""
 ARG GITHUB_PRIVATE_KEY=""
 
+# Maybe checkout something better than HEAD?
+RUN git clone https://github.com/occam-ra/occam.git
+
 # Configure git with the build arguments if provided
+#Need to change origin
 RUN if [ -n "$GITHUB_USERNAME" ] && [ -n "$GITHUB_EMAIL" ]; then \
       git config --global user.name "$GITHUB_USERNAME" && \
       git config --global user.email "$GITHUB_EMAIL"; \
+      git remote set-url origin git@github.com:occam-ra/occam.git;\
     fi
 
 # Create the .ssh directory and copy the private key if provided
@@ -44,33 +49,8 @@ RUN if [ -n "$GITHUB_PRIVATE_KEY" ]; then \
       echo "Host github.com\n  IdentityFile /root/.ssh/id_rsa" > /root/.ssh/config; \
     fi
 
-WORKDIR /var/www
-# Maybe checkout something better than HEAD?
-RUN git clone git@github.com:occam-ra/occam.git .
 
 WORKDIR occam
-# This no longer seems to work. It looks like the version of igraph-core is now invalid.
-#RUN pip install python-igraph==0.7.1.post6
-# Moving to igraph-0.8.0 requires some new build tools
-# This command now fails -- perhaps they've been EOL'd?
-#RUN apt-get update && apt-get install -y wget dpkg-dev
-#RUN wget http://ports.ubuntu.com/pool/main/libs/libsigsegv/libsigsegv2_2.10-4_arm64.deb
-#RUN dpkg -i libsigsegv2_2.10-4_arm64.deb
-#RUN rm libsigsegv2_2.10-4_arm64.deb
-#RUN wget http://ports.ubuntu.com/pool/main/m/m4/m4_1.4.17-5_arm64.deb
-#RUN dpkg -i m4_1.4.17-5_arm64.deb
-#RUN rm m4_1.4.17-5_arm64.deb
-#RUN wget http://ports.ubuntu.com/pool/main/a/autotools-dev/autotools-dev_20150820.1_all.deb \
-#    http://ports.ubuntu.com/pool/main/b/bison/libbison-dev_3.0.4.dfsg-1_arm64.deb \
-#    http://ports.ubuntu.com/pool/main/f/flex/libfl-dev_2.6.0-11_arm64.deb
-#RUN dpkg -i *.deb
-#RUN rm *.deb
-#RUN wget http://ports.ubuntu.com/pool/main/a/autoconf/autoconf_2.69-9_all.deb \
-#    http://ports.ubuntu.com/pool/main/libt/libtool/libtool_2.4.6-0.1_all.deb \
-#    http://ports.ubuntu.com/pool/main/b/bison/bison_3.0.4.dfsg-1_arm64.deb \
-#    http://ports.ubuntu.com/pool/main/f/flex/flex_2.6.0-11_arm64.deb
-#RUN dpkg -i *.deb
-
 # Install igraph
 RUN pip install python-igraph==0.8.0
 

--- a/podman/Dockerfile
+++ b/podman/Dockerfile
@@ -34,7 +34,6 @@ ARG GITHUB_PRIVATE_KEY=""
 RUN git clone https://github.com/occam-ra/occam.git
 
 # Configure git with the build arguments if provided
-#Need to change origin
 RUN if [ -n "$GITHUB_USERNAME" ] && [ -n "$GITHUB_EMAIL" ]; then \
       git config --global user.name "$GITHUB_USERNAME" && \
       git config --global user.email "$GITHUB_EMAIL"; \


### PR DESCRIPTION
The current implementation of chi squared self-describes as a "quick approximation." On evaluation it meets its description for accuracy, but this is less accurate than libboost by factors that could be significant (> 0.001 at df=4 and 5 and > 0.0006 at df=2). For performance, at x=1.5 and DF=2 the occam implementation is always 8-10x and frequently 100x slower on recent intel arch. Total runs summed over test cases for df=1 to df=10, libboost is always around twice as fast, and frequently 10x faster.

This does not yet replace the built-in csa function with csa_boost, but provides the potential replacement code and creates a test case (which the current csa function fails, using the libboost library csa function as the standard of accuracy).