### PR TITLE
Modify action logic to also accept empty action string.

### DIFF
--- a/py/weboccam.py
+++ b/py/weboccam.py
@@ -201,7 +201,8 @@ def printForm(formFields):
     untrusted_action = formFields.get("action", "")
 
     # validate the action by checking for it's presence in the allowlist
-    if untrusted_action in valid_actions:
+    # if action string is empty, we load the set of actions
+    if untrusted_action in valid_actions or not untrusted_action:
         action = untrusted_action
     else:
         # exit if the action is invalid


### PR DESCRIPTION
Fixes the issue with the webui not loading by also accepting no action and using that to load the possible actions form, as intended by the app.

Not sure how this ever worked without this change.

My issue was different because my git repo was cached at a previous commit in podman build. Sending another fix for that.