### PR TITLE
Fix hypergraph plotting functionality

### DIFF
--- a/podman/Dockerfile
+++ b/podman/Dockerfile
@@ -1,12 +1,10 @@
 #podman build -t build_occam:20230328 .
 # Built against an old ubuntu that was a contemporary to the source
 FROM ubuntu:16.04
-
 # Run the container in our timezone so logs are easier to process
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 RUN ln -sf /usr/share/zoneinfo/US/Pacific /etc/localtime
-
 RUN apt-get update
 RUN apt install -y tzdata
 RUN dpkg-reconfigure -f noninteractive tzdata
@@ -17,28 +15,31 @@ RUN apt install -y git gcc build-essential libgmp3-dev python-dev libxml2 libxml
 RUN apt install -y libtool autoconf bison flex
 RUN apt install -y git vim openssh-client
 RUN apt install -y libboost-math-dev
+
+# Graphics libraries for Cairo/igraph plotting - ADDED FOR GRAPHICS FIX
+RUN apt install -y \
+    libcairo2-dev \
+    python-cairo-dev \
+    pkg-config \
+    python-gi-dev \
+    libgirepository1.0-dev
+
 # Set up build arguments with default values
 ARG GITHUB_USERNAME
 ARG GITHUB_EMAIL
 ARG GITHUB_PRIVATE_KEY
-
 WORKDIR /var/www
-
 # Prevent caching outdated repo
 ADD https://api.github.com/repos/occam-ra/occam /tmp/repo-info.json
-
 # Maybe checkout something better than HEAD?
 RUN git clone https://github.com/occam-ra/occam.git
-
 WORKDIR occam
-
 # Configure git with the build arguments if provided
 RUN if [ -n "$GITHUB_USERNAME" ] && [ -n "$GITHUB_EMAIL" ]; then \
       git config --global user.name "$GITHUB_USERNAME" && \
       git config --global user.email "$GITHUB_EMAIL" && \
       git remote set-url origin git@github.com:occam-ra/occam.git; \
     fi
-
 # Create the .ssh directory and copy the private key if provided
 RUN if [ -n "$GITHUB_PRIVATE_KEY" ]; then \
       mkdir -p /root/.ssh && \
@@ -46,24 +47,16 @@ RUN if [ -n "$GITHUB_PRIVATE_KEY" ]; then \
       chmod 600 /root/.ssh/id_github && \
       echo "Host github.com\n  IdentityFile /root/.ssh/id_github" > /root/.ssh/config; \
     fi
-
-# Install igraph
+# Install igraph (now with graphics support!)
 RUN pip install python-igraph==0.8.0
-
 RUN a2enmod cgi
-
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
-
 # Maybe put some effort into making this into a multi-stage build if keeping the container process is favored.
 # Some of the libs installed above and the apache bits may be needed both in build and deploy. But for now.... complete the install in
 # this build layer.
-
 RUN make install
  
 RUN chown -R www-data: /var/www/occam/install/web/data
-
 COPY 000-default.conf /etc/apache2/sites-enabled
-
 EXPOSE 80
-
 CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/py/ocGraph.py
+++ b/py/ocGraph.py
@@ -65,7 +65,7 @@ def textwidth(text, fontsize=14):
     try:
         import cairo
     except Exception, e:
-        return len(str) * fontsize
+        return len(text) * fontsize
     surface = cairo.SVGSurface('data/undefined.svg', 600, 600)
     cr = cairo.Context(surface)
     cr.select_font_face('sans-serif', cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_BOLD)


### PR DESCRIPTION
Noticed after installing and testing on Docker that an error was coming at the very end of the Fit output. 
- Add Cairo graphics libraries to Dockerfile before igraph installation
- Fix variable name bug in ocGraph.py textwidth function (str -> text)  
- Enables proper hypergraph visualization in web interface

Fixes rendering issues preventing graph display